### PR TITLE
Adipasquale/4379 add activity button description

### DIFF
--- a/web/src/layout/nav/SecondaryNav.js
+++ b/web/src/layout/nav/SecondaryNav.js
@@ -22,6 +22,9 @@ const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
     <Fragment>
       {showAddActivityLink && (
         <div className="pre-button-section-break">
+          <div className="button-description">
+            Create an Additional Activity
+          </div>
           <Link
             to={`/apd/${apdId}/activities`}
             onClick={addActivity}

--- a/web/src/layout/nav/SecondaryNav.test.js
+++ b/web/src/layout/nav/SecondaryNav.test.js
@@ -19,6 +19,14 @@ const setup = (props = {}) => {
 };
 
 describe('Secondary Nav component', () => {
+  it('renders with activity button description when activity button is diplayed', () => {
+    const component = setup();
+    const activityButton = component.find('Link');
+    const buttonDescription = component.find('.button-description');
+    expect(activityButton.text()).toEqual('Add Activity');
+    expect(buttonDescription.text()).toEqual('Create an Additional Activity');
+  });
+
   it('renders with add activity button when on the last activity on the FFP section', () => {
     const component = setup();
     expect(component.find('Link').exists()).toBe(true);

--- a/web/src/styles/scss/secondary-nav.scss
+++ b/web/src/styles/scss/secondary-nav.scss
@@ -1,3 +1,7 @@
+.button-description {
+  padding-bottom: 16px;
+}
+
 .pre-button-section-break {
   margin: $spacer-4 0;
   padding-top: $spacer-4;


### PR DESCRIPTION
Resolves #4379 

### Description
Adds text above the Add Activity button to give the user clarity.

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |
| Viewing the Budget & FFP activity page of an APD |  Add Activity button displays  | Helper text above the button should also display | jest |

### Steps to manually verify this change

1. For an APD, go to the Budget & FFP page (last page/section) within an activity and scroll to the bottom to verify the text "Create an Additional Activity" exists above the Add Activity button per the [Figma designs](https://www.figma.com/file/hJpKHKU6fz5J0Z7fisSwa2/eAPD-MMIS-2022?node-id=2214%3A16213&t=w9nkrMFYRBbViq7U-0).

### This pull request is ready to code review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] New automated test cases are documented above
- [ ] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [ ] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
