### PR TITLE
NZ/4419 remove validation flag

### DIFF
--- a/web/src/containers/Root.js
+++ b/web/src/containers/Root.js
@@ -1,25 +1,14 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
-import { withLDProvider, useFlags } from 'launchdarkly-react-client-sdk';
+import { withLDProvider } from 'launchdarkly-react-client-sdk';
 
 import { setLatestActivity } from '../redux/actions/auth';
-import { updateFlags } from '../redux/actions/flags';
 
 import App from './App';
 
 const Root = ({ history, store }) => {
-  // when the app opens, get all of the flags
-  // update the flags you are watching here
-  const { validation = true } = useFlags();
-
-  // use the updateFlags action if a reducer needs to use a flag
-  // then it can listen for the FLAGS_UPDATED type
-  useEffect(() => {
-    store.dispatch(updateFlags({ validation }));
-  }, [validation]); // eslint-disable-line react-hooks/exhaustive-deps
-
   // Create listener for location changing to track activity
   history.listen(() => {
     store.dispatch(setLatestActivity());


### PR DESCRIPTION
Resolves #4419 

### Description
We no longer need the validation Launch Darkly flag. Let's use this opportunity during dev sync to practice removing LD flags from our codebase.

### Significant changes or possible side effects

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |
| Validation LD flag | is removed | does not interrupt the application | N/A |

### Steps to manually verify this change

1. validation flag has been removed
2. Anything related to validation still works as normal

### This pull request is ready to code review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] New automated test cases are documented above
- [ ] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [x] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
