### PR TITLE
NZ/4514 - APD name should be required in the new APD form

### DIFF
--- a/common/schemas/apdNew.js
+++ b/common/schemas/apdNew.js
@@ -9,7 +9,11 @@ const apdNewSchema = Joi.object({
       'any.only': 'Select an APD Type.',
       'any.required': 'Select an APD Type.'
     }),
-  name: Joi.any(),
+  name: Joi.string().trim().min(1).required().messages({
+    'any.only': 'Provide an APD name.',
+    'any.required': 'Provide an APD name.',
+    'string.min': 'Provide an APD name'
+  }),
   years: Joi.array().min(1).required().messages({
     'array.min': 'Select at least one year.'
   }),

--- a/common/schemas/apdNew.js
+++ b/common/schemas/apdNew.js
@@ -12,6 +12,7 @@ const apdNewSchema = Joi.object({
   name: Joi.string().trim().min(1).required().messages({
     'any.only': 'Provide an APD name.',
     'any.required': 'Provide an APD name.',
+    'string.empty': 'Provide an APD name',
     'string.min': 'Provide an APD name'
   }),
   years: Joi.array().min(1).required().messages({

--- a/web/src/pages/apd/new/ApdNew.js
+++ b/web/src/pages/apd/new/ApdNew.js
@@ -221,6 +221,8 @@ const ApdNew = ({ createApd: create }) => {
                     {...props}
                     label="APD Name"
                     className="remove-clearfix"
+                    errorMessage={errors?.name?.message}
+                    errorPlacement="bottom"
                   />
                 )}
               />

--- a/web/src/pages/apd/new/ApdNew.test.js
+++ b/web/src/pages/apd/new/ApdNew.test.js
@@ -49,14 +49,14 @@ const setup = async (props = {}, options = {}) => {
 describe('<ApdNew />', () => {
   jest.setTimeout(30000);
 
-  describe('form with Mmis disabled', () => {
+  describe('form with MMIS disabled', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       resetLDMocks();
       mockFlags({ enableMmis: false });
     });
 
-    it('should not show Mmis option', async () => {
+    it('should not show MMIS option', async () => {
       await setup(props, options);
       expect(
         screen.getByText(/Create a New Advanced Planning Document/)
@@ -74,13 +74,17 @@ describe('<ApdNew />', () => {
 
     it('requires all fields to enable Create APD button', async () => {
       const { user } = await setup(props, options);
+      const disabledBtn = screen.getByRole('button', { name: /Create an APD/ });
       expect(screen.getByRole('radio', { name: /HITECH IAPD/i })).toBeChecked();
 
-      expect(
-        screen.getByRole('button', {
-          name: /Create an APD/
-        })
-      ).toBeDisabled();
+      expect(disabledBtn).toBeDisabled();
+
+      await user.type(
+        screen.getByRole('textbox', { name: /name/i }),
+        'APD Name'
+      );
+
+      expect(disabledBtn).toBeDisabled();
 
       expect(screen.getByRole('checkbox', { name: /2023/i })).toBeChecked();
       expect(screen.getByRole('checkbox', { name: /2024/i })).toBeChecked();
@@ -100,19 +104,19 @@ describe('<ApdNew />', () => {
         ).toBeChecked();
       });
       await waitFor(() => {
-        expect(
-          screen.getByRole('button', {
-            name: /Create an APD/
-          })
-        ).toBeEnabled();
+        expect(disabledBtn).toBeEnabled();
       });
     });
   });
 
-  describe('form with Mmis enabled', () => {
-    it('should display form with MMIS', async () => {
+  describe('form with MMIS enabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      resetLDMocks();
       mockFlags({ enableMmis: true });
+    });
 
+    it('should display form with MMIS', async () => {
       await setup(props, options);
       expect(
         screen.getByText(/Create a New Advanced Planning Document/)
@@ -124,12 +128,6 @@ describe('<ApdNew />', () => {
     });
 
     describe('selecting and filling out HITECH form', () => {
-      beforeEach(() => {
-        jest.clearAllMocks();
-        resetLDMocks();
-        mockFlags({ enableMmis: true });
-      });
-
       it('HITECH selected should show HITECH form', async () => {
         const { user } = await setup(props, options);
         user.click(screen.getByRole('radio', { name: /HITECH IAPD/i }));
@@ -164,7 +162,10 @@ describe('<ApdNew />', () => {
 
         expect(disabledBtn).toBeDisabled();
 
-        user.type(screen.getByRole('textbox', { name: /name/i }), 'APD Name');
+        await user.type(
+          screen.getByRole('textbox', { name: /name/i }),
+          'APD Name'
+        );
 
         expect(disabledBtn).toBeDisabled();
 
@@ -232,7 +233,11 @@ describe('<ApdNew />', () => {
         });
         expect(disabledBtn).toBeDisabled();
 
-        user.type(screen.getByRole('textbox', { name: /name/i }), 'APD Name');
+        await user.type(
+          screen.getByRole('textbox', { name: /name/i }),
+          'APD Name'
+        );
+
         expect(disabledBtn).toBeDisabled();
 
         expect(screen.getByRole('checkbox', { name: /2023/i })).toBeChecked();


### PR DESCRIPTION
Resolves #4514 

### Description
The new APD form should require the APD name have a value

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |
| a user is creating an APD | the name field hasn't been touched | the Create new APD button should be disabled | jest |
| a user is creating an APD | the name field is empty and has been touched | the error message displays below the field and the Create new APD button should be disabled | jest |
| a user is creating an APD | the name field is filled out and the rest of the form is valid | the Create new APD button is enabled | jest |

### Steps to manually verify this change

1.  Go to create a new APD
2. Select APD name field and go off, ensure error message shows
3. You can only create an APD if a name is supplied

### This pull request is ready to code review when

- [x] Automated tests are updated (and all tests are passing)
- [x] New automated test cases are documented above
- [x] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [x] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [x] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [x] Product has approved the experience
