### PR TITLE
bbrooks/4461-BASH-to-User-Data

### DIFF
--- a/terraform/legacy/prod/modules/mongo.tf
+++ b/terraform/legacy/prod/modules/mongo.tf
@@ -39,5 +39,6 @@ resource "aws_instance" "eapd_mongo" {
     user_data = <<-EOL
     #!/bin/bash -xe
     sudo sh -c "echo license_key: ${var.newrelic_liscense_key} >> /etc/newrelic-infra.yml"
-    EOL        
+    EOL
+    user_data_replace_on_change = true
 }

--- a/terraform/legacy/public/modules/instances/eapd_jumpbox.tf
+++ b/terraform/legacy/public/modules/instances/eapd_jumpbox.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "eapd_jumpbox_bb" {
         "Patch Group" = "RHEL7"
         "cms-cloud-exempt:open-sg" = "CLDSPT-5877"
         "Patch Window" = "ITOPS-Wave1-Non-Mktplc-Prod-MW"
-        Terraform = "True"        
+        Terraform = "True"
     }   
 }
 

--- a/terraform/legacy/staging/modules/mongo.tf
+++ b/terraform/legacy/staging/modules/mongo.tf
@@ -36,5 +36,6 @@ resource "aws_instance" "eapd_mongo" {
     user_data = <<-EOL
     #!/bin/bash -xe
     sudo sh -c "echo license_key: ${var.newrelic_liscense_key} >> /etc/newrelic-infra.yml"
-    EOL    
+    EOL
+    user_data_replace_on_change = true
 }


### PR DESCRIPTION
Resolves # 4461

### Description
Was meant to update Terraform and Packer code to use AWS user_data scripts instead of BASH scripts where possible. We were not using BASH scripts in Terraform anymore, and Packer doesn't have an AWS user_data provisioner, so all done. I added an option that will trigger a rebuild of Terraform infrastructure if the user_data scripts are updated.

### Significant changes or possible side effects
None 

### Automated test cases written
None

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |

### Steps to manually verify this change

1. 
2.
3.

### This pull request is ready to code review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] New automated test cases are documented above
- [ ] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [ ] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
