### PR TITLE
Dmirano/4510 state staff and expenses help text

### DIFF
--- a/web/src/i18n/locales/en/activities/expenses.yaml
+++ b/web/src/i18n/locales/en/activities/expenses.yaml
@@ -1,11 +1,20 @@
-instruction:
+instructionHITECH:
   detail: >-
     Provide a breakout and brief description of each non-personnel cost related
-    to this activity. These costs should only apply to state (in-house)
-    expenses and should not include costs related to private contractors.
+    to this activity. These costs should only apply to state (in-house) expenses
+    and should not include costs related to private contractors.
   helpText: >-
-    “Miscellaneous expenses” is one of the options in the drop-down menu. It includes
-    materials and supplies, communications‐related expenses, printing costs and
-    facilities expenses.
+    “Miscellaneous expenses” is one of the options in the drop-down menu. It
+    includes materials and supplies, communications‐related expenses, printing
+    costs and facilities expenses.
+instructionMMIS:
+  detail: >-
+    Provide a breakout and brief description of each non-personnel cost related
+    to this activity. These costs should only apply to state (in-house) expenses
+    and should not include costs related to private contractors.
+  helpText: >-
+    Refer to <a
+    href="https://www.medicaid.gov/federal-policy-guidance/downloads/SMD16004.pdf">SMDL
+    16-004</a> for guidance on allowable expenses and FFP rates.
 noDataNotice: Add other state expense(s) for this activity.
 addButtonText: Add State Expense

--- a/web/src/i18n/locales/en/activities/expenses.yaml
+++ b/web/src/i18n/locales/en/activities/expenses.yaml
@@ -14,7 +14,8 @@ instructionMMIS:
     and should not include costs related to private contractors.
   helpText: >-
     Refer to <a
-    href="https://www.medicaid.gov/federal-policy-guidance/downloads/SMD16004.pdf">SMDL
-    16-004</a> for guidance on allowable expenses and FFP rates.
+    href="https://www.medicaid.gov/federal-policy-guidance/downloads/SMD16004.pdf"
+    target="_blank">SMDL 16-004</a> for guidance on allowable expenses and FFP
+    rates.
 noDataNotice: Add other state expense(s) for this activity.
 addButtonText: Add State Expense

--- a/web/src/i18n/locales/en/activities/statePersonnel.yaml
+++ b/web/src/i18n/locales/en/activities/statePersonnel.yaml
@@ -1,14 +1,30 @@
-instruction:
+instructionHITECH:
   detail: >-
     The cost for state (in-house) staff with benefits is per full time employee
     (FTE). The number of FTEs represents the combined amount of staff time for
-    the duration of the activity. Combine multiple individuals’ commitments
-    only when their costs and roles are the same. Do not include contract
-    personnel in this section; account for them under Private Contractor Costs.
+    the duration of the activity. Combine multiple individuals’ commitments only
+    when their costs and roles are the same. Do not include contract personnel
+    in this section; account for them under Private Contractor Costs.
   helpText: >-
     For example: If two people work as Analyst Class 1 on this activity 75
-    percent of the time, record one entry of 1.5 FTE. If they are in different roles,
-    record two separate entries of 0.75 FTE.
+    percent of the time, record one entry of 1.5 FTE. If they are in different
+    roles, record two separate entries of 0.75 FTE.
+
+instructionMMIS:
+  detail: >-
+    The cost for state (in-house) staff with benefits is per full time employee
+    (FTE). The number of FTEs represents the combined amount of staff time for
+    the duration of the activity. Combine multiple individuals’ commitments only
+    when their costs and roles are the same. Do not include contract personnel
+    in this section; account for them under Private Contractor Costs.
+  helpText: >-
+    **Example**: Two Auditors, Class 1, working at 75% time = Auditor, Class 1
+    at 1.5 FTE
+
+
+    **Example**: Two Auditors, Class 1 and Class 2, working at 75% time =
+    Auditor, Class 1, 0.75 and Auditor, class 2, 0.75 FTE.
+
 noDataNotice: State staff have not been added for this activity.
 labels:
   entryNum: '#'

--- a/web/src/pages/apd/activities/state-costs/NonPersonnelCosts.js
+++ b/web/src/pages/apd/activities/state-costs/NonPersonnelCosts.js
@@ -17,12 +17,14 @@ import { selectApdYears } from '../../../../redux/selectors/apd.selectors';
 import { selectActivityNonPersonnelCosts } from '../../../../redux/selectors/activities.selectors';
 import Instruction from '../../../../components/Instruction';
 import { t } from '../../../../i18n';
+import { selectApdType } from '../../../../redux/selectors/apd.selectors';
 
 const NonPersonnelCosts = ({
   activityIndex,
   expenses,
   removeExpense,
-  years
+  years,
+  apdType
 }) => {
   const [localList, setLocalList] = useState(expenses);
 
@@ -45,7 +47,7 @@ const NonPersonnelCosts = ({
 
   return (
     <Fragment>
-      <Instruction source="activities.expenses.instruction" />
+      <Instruction source={`activities.expenses.instruction${apdType}`} />
       <FormAndReviewList
         activityIndex={activityIndex}
         addButtonText={t('activities.expenses.addButtonText')}
@@ -66,12 +68,14 @@ NonPersonnelCosts.propTypes = {
   activityIndex: PropTypes.number.isRequired,
   expenses: PropTypes.array.isRequired,
   removeExpense: PropTypes.func.isRequired,
-  years: PropTypes.arrayOf(PropTypes.string).isRequired
+  years: PropTypes.arrayOf(PropTypes.string).isRequired,
+  apdType: PropTypes.string.isRequired
 };
 
 const mapStateToProps = (state, { activityIndex }) => ({
   expenses: selectActivityNonPersonnelCosts(state, activityIndex),
-  years: selectApdYears(state)
+  years: selectApdYears(state),
+  apdType: selectApdType(state)
 });
 
 const mapDispatchToProps = {

--- a/web/src/pages/apd/activities/state-costs/NonPersonnelCosts.test.js
+++ b/web/src/pages/apd/activities/state-costs/NonPersonnelCosts.test.js
@@ -66,7 +66,7 @@ describe('activity non-personnel costs subsection', () => {
         },
         { activityIndex: 2 }
       )
-    ).toEqual({ expenses: 'these are expenses' });
+    ).toEqual({ expenses: 'these are expenses', apdType: 'HITECH' });
   });
 
   it('maps dispatch actions to props', () => {

--- a/web/src/pages/apd/activities/state-costs/StatePersonnel.js
+++ b/web/src/pages/apd/activities/state-costs/StatePersonnel.js
@@ -12,8 +12,15 @@ import { selectActivityStatePersonnel } from '../../../../redux/selectors/activi
 import { selectApdYears } from '../../../../redux/selectors/apd.selectors';
 import { newStatePerson } from '../../../../redux/reducers/activities';
 import { removePersonnel } from '../../../../redux/actions/editActivity';
+import { selectApdType } from '../../../../redux/selectors/apd.selectors';
 
-const StatePersonnel = ({ activityIndex, personnel, remove, years }) => {
+const StatePersonnel = ({
+  activityIndex,
+  personnel,
+  remove,
+  years,
+  apdType
+}) => {
   const [localList, setLocalList] = useState(personnel);
 
   useEffect(() => {
@@ -33,7 +40,7 @@ const StatePersonnel = ({ activityIndex, personnel, remove, years }) => {
 
   return (
     <Fragment>
-      <Instruction source="activities.statePersonnel.instruction" />
+      <Instruction source={`activities.statePersonnel.instruction${apdType}`} />
       <FormAndReviewList
         activityIndex={activityIndex}
         addButtonText={t('activities.statePersonnel.addButtonText')}
@@ -54,12 +61,14 @@ StatePersonnel.propTypes = {
   activityIndex: PropTypes.number.isRequired,
   personnel: PropTypes.array.isRequired,
   remove: PropTypes.func.isRequired,
-  years: PropTypes.arrayOf(PropTypes.string).isRequired
+  years: PropTypes.arrayOf(PropTypes.string).isRequired,
+  apdType: PropTypes.string.isRequired
 };
 
 const mapStateToProps = (state, { activityIndex }) => ({
   personnel: selectActivityStatePersonnel(state, { activityIndex }),
-  years: selectApdYears(state)
+  years: selectApdYears(state),
+  apdType: selectApdType(state)
 });
 
 const mapDispatchToProps = {

--- a/web/src/pages/apd/activities/state-costs/StatePersonnel.test.js
+++ b/web/src/pages/apd/activities/state-costs/StatePersonnel.test.js
@@ -61,7 +61,7 @@ describe('activity state personnel costs subsection', () => {
         },
         { activityIndex: 0 }
       )
-    ).toEqual({ personnel: 'these are personnel' });
+    ).toEqual({ personnel: 'these are personnel', apdType: 'HITECH' });
   });
 
   it('maps dispatch actions to props', () => {

--- a/web/src/pages/apd/activities/state-costs/__snapshots__/NonPersonnelCosts.test.js.snap
+++ b/web/src/pages/apd/activities/state-costs/__snapshots__/NonPersonnelCosts.test.js.snap
@@ -12,7 +12,7 @@ exports[`activity non-personnel costs subsection renders correctly 1`] = `
     }
     labelFor={null}
     reverse={false}
-    source="activities.expenses.instruction"
+    source="activities.expenses.instructionundefined"
   />
   <FormAndReviewList
     activityIndex={58}

--- a/web/src/pages/apd/activities/state-costs/__snapshots__/StatePersonnel.test.js.snap
+++ b/web/src/pages/apd/activities/state-costs/__snapshots__/StatePersonnel.test.js.snap
@@ -12,7 +12,7 @@ exports[`activity state personnel costs subsection renders correctly 1`] = `
     }
     labelFor={null}
     reverse={false}
-    source="activities.statePersonnel.instruction"
+    source="activities.statePersonnel.instructionundefined"
   />
   <FormAndReviewList
     activityIndex={72}


### PR DESCRIPTION
Resolves #4510 

### Description
Updates help text for the mmis state staff and expenses page

### Significant changes or possible side effects
None, all changes isolated to state staff and expenses page

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |

### Steps to manually verify this change

1. Open a HITECH APD and verify the state staff and expenses has the old help text
2. Open a MMIS APD and verify the state staff and expenses has the new help text

### This pull request is ready to code review when

- [x] Automated tests are updated (and all tests are passing)
- [x] New automated test cases are documented above
- [x] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [ ] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
