### PR TITLE
Adding SGs for DataProtect to reach eAPD DBs

### DIFF
--- a/terraform/legacy/prod/modules/buckets.tf
+++ b/terraform/legacy/prod/modules/buckets.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_public_access_block" "eapd-cpm-bucket-public-access-bloc
 resource "aws_s3_bucket_versioning" "eapd-cpm-bucket-versioning" {
   bucket = aws_s3_bucket.eapd-cpm-bucket.id
   versioning_configuration {
-    status = "Enabled"
+    status = "Disabled"
   }
 }
 
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "bucket-require-tls" {
 
     principals {
       type        = "AWS"
-      identifiers = [ var.aws_account_id]
+      identifiers = [ "*" ]
     }
 
     actions = ["s3:*",]

--- a/terraform/legacy/prod/modules/mongo.tf
+++ b/terraform/legacy/prod/modules/mongo.tf
@@ -15,7 +15,7 @@ resource "aws_instance" "eapd_mongo" {
     #ami                         = data.aws_ami.latest_mongo_image.id
     ami                         = "ami-0610f22bf733e32ed"
     instance_type               = "m3.medium"
-    vpc_security_group_ids      = ["sg-01e01435dbbe6ce32", aws_security_group.eapd-production-mongo-ec2.id]
+    vpc_security_group_ids      = ["sg-01e01435dbbe6ce32", aws_security_group.eapd-production-mongo-ec2.id, aws_security_group.eapd-pro-dbprotect-mongo.id]
     subnet_id                   = "subnet-07e1b9ed6ed5fb8c7"
     key_name                    = "eapd_bbrooks"
     iam_instance_profile        = "CCSPatchRole"
@@ -40,5 +40,5 @@ resource "aws_instance" "eapd_mongo" {
     #!/bin/bash -xe
     sudo sh -c "echo license_key: ${var.newrelic_liscense_key} >> /etc/newrelic-infra.yml"
     EOL
-    user_data_replace_on_change = true
+    #user_data_replace_on_change = true
 }

--- a/terraform/legacy/prod/modules/securityGroups.tf
+++ b/terraform/legacy/prod/modules/securityGroups.tf
@@ -43,3 +43,41 @@ resource "aws_security_group" "eapd-production-mongo-ec2" {
     Terraform = "Yes"
   }
 }
+
+resource "aws_security_group" "eapd-pro-dbprotect-mongo" {
+  name        = "eapd-prod-allow-dbprotect-mongo"
+  description = "Mongo instance security group"
+  vpc_id      = data.aws_vpc.HI-C-dev-vpc.id
+
+  ingress {
+    description = "Mongo Access for DB Protect"
+    from_port   = 27017
+    to_port     = 27019
+    protocol    = "tcp"
+    cidr_blocks = ["10.223.125.0/24", "10.242.216.0/24", "10.203.143.0/25"]
+  }
+
+  tags = {
+    Name = "eapd-prod-allow-dbprotect-mongo"
+    Terraform = "Yes"
+  }
+}
+
+resource "aws_security_group" "eapd-pro-dbprotect-postgres" {
+  name        = "eapd-prod-allow-dbprotect-postgres"
+  description = "Postgres instance security group"
+  vpc_id      = data.aws_vpc.HI-C-dev-vpc.id
+
+  ingress {
+    description = "Postgres Access for DB Protect"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["10.223.125.0/24", "10.242.216.0/24", "10.203.143.0/25"]
+  }
+
+  tags = {
+    Name = "eapd-prod-allow-dbprotect-postgres"
+    Terraform = "Yes"
+  }
+}


### PR DESCRIPTION
Resolves # Request from Nathan ODonnell

### Description
Adds security groups to eAPD Mongo and PostGres databases to allow scanning for DBProtect.

### Significant changes or possible side effects
If Terraform is run globally it would require the re-provisioning of resources, including the Mongo databases. To mitigate this I created the SGs and updated the Mongo instance Terraform code to include the SGs, but only used Terraform to provision the new SGs and manually updated the existing Mongo instances manually.

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |

### Steps to manually verify this change

1.
2.
3.

### This pull request is ready to code review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] New automated test cases are documented above
- [ ] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [ ] Code has been reviewed by someone other than the original author

### This pull request is ready to review when the QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
