### PR TITLE
bbrooks/circleci-store-artifacts-20230317

### DIFF
--- a/bin/prod-deploy/buildurl.sh
+++ b/bin/prod-deploy/buildurl.sh
@@ -1,1 +1,1 @@
-curl -vvv -H "${CIRCLE_TOKEN}" -L https://circleci.com/api/v2/project/gh/Enterprise-CMCS/eAPD/${CIRCLE_BUILD_NUM}/artifacts |grep -o 'https://[^"]*' |grep backend.zip > build-url.txt
+curl -vvv -H "Circle-Token: ${CIRCLE_TOKEN}" -L https://circleci.com/api/v1.1/project/gh/Enterprise-CMCS/eAPD/${CIRCLE_BUILD_NUM}/artifacts |grep -o 'https://[^"]*' |grep backend.zip > build-url.txt


### PR DESCRIPTION
Resolves # Retrieving Stored Artifacts not working

### Description
The retrieving of stored artifacts for staging seems to have broke. This remedies the issue by falling back to v1.1 of the CircleCI API, which worked in testing.

### Chromatic Link

### Significant changes or possible side effects

### Automated test cases written

| Given | When | Then | Type (jest, tap, cypress) |
| ----- | ---- | ---- | ------------------------- |

### Steps to manually verify this change

1.
2.
3.

### This pull request is ready to code review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] New automated test cases are documented above
- [ ] Chromatic link added above
- [ ] Pull request has been labeled, if applicable with feature, content, bug,
      tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav,
      screenreader, text scaling) OR an exemption is documented

### This pull request is ready to test when

- [ ] Code has been reviewed by someone other than the original author

### This pull request is ready to review when QA has

- [ ] Verified the functionality related to the change
- [ ] Verified that the change works with Narrator on Windows
- [ ] Verified that the change works with VoiceOver on Mac
- [ ] Verified all updated pages with the WAVE tool
- [ ] Verified tab and keyboard navigation functionality

### This pull request can be merged when

- [ ] Design has approved the experience
- [ ] Product has approved the experience
